### PR TITLE
Add announcements grid display

### DIFF
--- a/app/(app)/(front)/announcements/page.tsx
+++ b/app/(app)/(front)/announcements/page.tsx
@@ -1,3 +1,10 @@
+import {AnnouncementGrid} from '@/components/announcement/grid'
+
 export default function Announcements() {
-  return <main></main>
+  return (
+    <main>
+      <h1 className="text-4xl font-bold text-center mb-6">Announcements</h1>
+      <AnnouncementGrid />
+    </main>
+  )
 }

--- a/components/announcement/grid.tsx
+++ b/components/announcement/grid.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardImage,
+  CardTitle
+} from '@/components/ui/card'
+
+import {useQuery} from '@/hooks/use-query'
+
+import {Media} from '@/payload-types'
+
+import Link from 'next/link'
+import {useSearchParams} from 'next/navigation'
+import {Pagination} from '../pagination'
+
+export function AnnouncementGrid() {
+  const searchParams = useSearchParams()
+  const defaultLimit = 12
+  const page = parseInt(searchParams.get('page') || '1') // if page is 0 or NaN, default to 1
+  const limit = parseInt(searchParams.get('limit') || defaultLimit.toString())
+
+  const {data, isLoading, error} = useQuery('school-announcements', {
+    depth: 1,
+    pagination: true,
+    limit,
+    page
+  })
+
+  if (isLoading) {
+    return <p>Loading...</p>
+  }
+
+  if (error) {
+    return <p>Failed to load announcements: {error.message}</p>
+  }
+
+  if (!data) {
+    return <p>No data</p>
+  }
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+        {data.docs.map(ann => {
+          return (
+            <article
+              className="relative transition-transform hover:scale-105"
+              key={ann.id}>
+              <Card className="shadow-md h-full">
+                {ann.thumbnail && (
+                  <CardImage src={(ann.thumbnail as Media).cdn_url!} alt={ann.title} className="max-h-48" />
+                )}
+                <CardHeader>
+                  <CardTitle>{ann.title}</CardTitle>
+                  <CardDescription>
+                    {new Date(ann.createdAt).toLocaleString()}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div
+                    className="prose line-clamp-3"
+                    dangerouslySetInnerHTML={{__html: ann.bodyHTML!}}
+                  />
+                </CardContent>
+              </Card>
+              <Link
+                href={`/announcements/${ann.id}`}
+                className="absolute inset-0 z-10"
+              />
+            </article>
+          )
+        })}
+      </div>
+      <div className="mx-auto">
+        <Pagination
+          totalPages={data.totalPages}
+          hasPrevPage={data.hasPrevPage}
+          hasNextPage={data.hasNextPage}
+          defaultLimit={defaultLimit}
+        />
+      </div>
+    </div>
+  )
+}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import {cn} from '@/lib/utils'
+import Image from 'next/image'
 
 const Card = React.forwardRef<
   HTMLDivElement,
@@ -76,4 +77,12 @@ const CardFooter = React.forwardRef<
 ))
 CardFooter.displayName = 'CardFooter'
 
-export {Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent}
+const CardImage = React.forwardRef<
+  HTMLImageElement,
+  React.ComponentProps<typeof Image>
+>(({ className, ...props }, ref) => (
+  <Image ref={ref} className={cn("h-auto w-full object-cover max-h-48", className)} height={0} width={0} sizes="100vw" {...props} />
+));
+CardImage.displayName = "CardImage";
+
+export {Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent, CardImage}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -10,7 +10,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      'rounded-lg border bg-card text-card-foreground shadow-sm',
+      'rounded-lg border bg-card text-card-foreground shadow-sm overflow-hidden',
       className
     )}
     {...props}
@@ -81,7 +81,7 @@ const CardImage = React.forwardRef<
   HTMLImageElement,
   React.ComponentProps<typeof Image>
 >(({ className, ...props }, ref) => (
-  <Image ref={ref} className={cn("h-auto w-full object-cover max-h-48", className)} height={0} width={0} sizes="100vw" {...props} />
+  <Image ref={ref} className={cn("h-auto w-full object-cover", className)} height={0} width={0} sizes="100vw" {...props} />
 ));
 CardImage.displayName = "CardImage";
 


### PR DESCRIPTION
This pull request introduces a new `AnnouncementGrid` component and updates the `Announcements` page to display a grid of announcements. It also includes enhancements to the `Card` component to support images.

### Announcements Page and Grid Component:

* [`app/(app)/(front)/announcements/page.tsx`](diffhunk://#diff-1c2896db9db6e1bce817331fa57cd590e6fc9aa46c9575a0f3f4a08e8d2819b8R1-R9): Updated the `Announcements` page to include a header and the `AnnouncementGrid` component.
* [`components/announcement/grid.tsx`](diffhunk://#diff-d2a7a3e1d2554ccb34ec4447733d31ca2728154ec5636cc8fdb84f2be3c8de60R1-R88): Added the `AnnouncementGrid` component, which fetches and displays a paginated list of announcements using the `useQuery` hook.

### Card Component Enhancements:

* `components/ui/card.tsx`: 
  * Imported `Image` from `next/image` to support card images.
  * Added `overflow-hidden` to the card container to ensure images are properly clipped.
  * Added a new `CardImage` component to display images within cards.