### PR TITLE
Refactor and update useQuery function

### DIFF
--- a/app/(app)/(front)/announcements/[slug]/page.tsx
+++ b/app/(app)/(front)/announcements/[slug]/page.tsx
@@ -26,7 +26,11 @@ export default function Announcement() {
     return <p>Failed to load announcement: {error.message}</p>
   }
 
-  const {title, createdAt, bodyHTML, thumbnail} = data!.docs[0]!
+  if (!data) {
+    return <p>No data</p>
+  }
+
+  const {title, createdAt, bodyHTML, thumbnail} = data.docs[0]
 
   return (
     <article>

--- a/app/(app)/(front)/announcements/[slug]/page.tsx
+++ b/app/(app)/(front)/announcements/[slug]/page.tsx
@@ -7,7 +7,8 @@ import {Media} from '@/payload-types'
 
 export default function Announcement() {
   const {slug} = useParams<{slug: string}>()
-  const {data, isLoading, error} = useQuery('school-announcements', {
+  const {data, isLoading, error} = useQuery({
+    collection: 'school-announcements',
     where: {
       id: {
         equals: slug

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,12 +1,10 @@
 import {Metadata} from 'next'
 import {Open_Sans} from 'next/font/google'
 import {Toaster} from '@/components/ui/toaster'
-
-import {QueryClient, QueryClientProvider, useQuery} from '@tanstack/react-query'
+import {ReactQueryClientProvider} from '@/components/QueryClientProvider'
 
 import './globals.css'
 
-const queryClient = new QueryClient()
 const nextFont = Open_Sans({subsets: ['latin']})
 
 export const metadata: Metadata = {
@@ -20,13 +18,13 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en">
-      <body className={nextFont.className}>
-        <QueryClientProvider client={queryClient}>
+    <ReactQueryClientProvider>
+      <html lang="en">
+        <body className={nextFont.className}>
           {children}
           <Toaster />
-        </QueryClientProvider>
-      </body>
-    </html>
+        </body>
+      </html>
+    </ReactQueryClientProvider>
   )
 }

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,9 +1,12 @@
 import {Metadata} from 'next'
 import {Open_Sans} from 'next/font/google'
-import './globals.css'
-
 import {Toaster} from '@/components/ui/toaster'
 
+import {QueryClient, QueryClientProvider, useQuery} from '@tanstack/react-query'
+
+import './globals.css'
+
+const queryClient = new QueryClient()
 const nextFont = Open_Sans({subsets: ['latin']})
 
 export const metadata: Metadata = {
@@ -19,8 +22,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={nextFont.className}>
-        {children}
-        <Toaster />
+        <QueryClientProvider client={queryClient}>
+          {children}
+          <Toaster />
+        </QueryClientProvider>
       </body>
     </html>
   )

--- a/components/QueryClientProvider.tsx
+++ b/components/QueryClientProvider.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import {useState} from 'react'
+
+export const ReactQueryClientProvider = ({
+  children
+}: {
+  children: React.ReactNode
+}) => {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            // With SSR, we usually want to set some default staleTime
+            // above 0 to avoid refetching immediately on the client
+            staleTime: 60 * 1000
+          }
+        }
+      })
+  )
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}

--- a/components/announcement/grid.tsx
+++ b/components/announcement/grid.tsx
@@ -23,7 +23,8 @@ export function AnnouncementGrid() {
   const page = parseInt(searchParams.get('page') || '1') // if page is 0 or NaN, default to 1
   const limit = parseInt(searchParams.get('limit') || defaultLimit.toString())
 
-  const {data, isLoading, error} = useQuery('school-announcements', {
+  const {data, isLoading, error} = useQuery({
+    collection: 'school-announcements',
     depth: 1,
     pagination: true,
     limit,

--- a/components/club/grid.tsx
+++ b/components/club/grid.tsx
@@ -22,7 +22,8 @@ export function ClubGrid() {
   const page = parseInt(searchParams.get('page') || '1') // if page is 0 or NaN, default to 1
   const limit = parseInt(searchParams.get('limit') || defaultLimit.toString())
 
-  const {data, isLoading, error} = useQuery('clubs', {
+  const {data, isLoading, error} = useQuery({
+    collection: 'clubs',
     depth: 1,
     pagination: true,
     limit,

--- a/components/contact/form.tsx
+++ b/components/contact/form.tsx
@@ -6,8 +6,8 @@ import {Input} from '@/components/ui/input'
 import {Textarea} from '@/components/ui/textarea'
 import {submitForm} from './actions'
 import {useToast} from '@/hooks/use-toast'
-import {useFormState, useFormStatus} from 'react-dom'
-import {useEffect} from 'react'
+import {useFormStatus} from 'react-dom'
+import {useActionState, useEffect} from 'react'
 
 function SubmitButton() {
   // Get the form status from the parent form
@@ -21,7 +21,7 @@ function SubmitButton() {
 
 export function ContactForm() {
   const {toast} = useToast() // get the toast function
-  const [state, action] = useFormState(submitForm, null) // get the form state
+  const [state, action] = useActionState(submitForm, null) // get the form state
   // show toast if state becomes true
   useEffect(() => {
     if (state === true) {

--- a/components/hero-sections/announcements.tsx
+++ b/components/hero-sections/announcements.tsx
@@ -12,9 +12,18 @@ export function Announcements() {
     sort: '-createdAt'
   }
 
-  const announcements = useQuery('school-announcements', queryOptions)
-  const satellite = useQuery('the-satellite-news', queryOptions)
-  const pararayos = useQuery('ang-pararayos-news', queryOptions)
+  const announcements = useQuery({
+    collection: 'school-announcements',
+    ...queryOptions
+  })
+  const satellite = useQuery({
+    collection: 'the-satellite-news',
+    ...queryOptions
+  })
+  const pararayos = useQuery({
+    collection: 'ang-pararayos-news',
+    ...queryOptions
+  })
 
   if (announcements.isLoading || satellite.isLoading || pararayos.isLoading) {
     // if any of the data is loading

--- a/hooks/server/payload-query.ts
+++ b/hooks/server/payload-query.ts
@@ -6,12 +6,16 @@ import {CollectionSlug} from 'payload'
 
 const payload = await getPayloadHMR({config})
 
+export type Options<TSlug extends CollectionSlug> = Parameters<
+  typeof payload.find<TSlug>
+>[0]
+
 export async function queryCollection<TSlug extends CollectionSlug>(
-  collection: TSlug,
-  options: Omit<Parameters<typeof payload.find<TSlug>>[0], 'collection'>
+  options:
+    | {
+        collection: TSlug
+      }
+    | Options<TSlug>
 ) {
-  return await payload.find({
-    collection,
-    ...options
-  })
+  return await payload.find(options)
 }

--- a/hooks/use-query.ts
+++ b/hooks/use-query.ts
@@ -1,6 +1,6 @@
-import useSWR from 'swr'
 import {CollectionSlug, PaginatedDocs, DataFromCollectionSlug} from 'payload'
 import {queryCollection} from './server/payload-query'
+import {useQuery as useReactQuery} from '@tanstack/react-query'
 
 // basically does a payload query but using useSWR and automatically casts
 // the return type to the collection's type
@@ -8,7 +8,8 @@ export function useQuery<TSlug extends CollectionSlug>(
   collection: TSlug,
   options: Omit<Parameters<typeof queryCollection>[1], 'collection'>
 ) {
-  return useSWR<PaginatedDocs<DataFromCollectionSlug<TSlug>>>(collection, () =>
-    queryCollection(collection, options)
-  )
+  return useReactQuery<PaginatedDocs<DataFromCollectionSlug<TSlug>>>({
+    queryKey: [collection, options],
+    queryFn: () => queryCollection(collection, options)
+  })
 }

--- a/hooks/use-query.ts
+++ b/hooks/use-query.ts
@@ -1,15 +1,18 @@
 import {CollectionSlug, PaginatedDocs, DataFromCollectionSlug} from 'payload'
-import {queryCollection} from './server/payload-query'
+import {Options, queryCollection} from './server/payload-query'
 import {useQuery as useReactQuery} from '@tanstack/react-query'
 
 // basically does a payload query but using useSWR and automatically casts
 // the return type to the collection's type
 export function useQuery<TSlug extends CollectionSlug>(
-  collection: TSlug,
-  options: Omit<Parameters<typeof queryCollection>[1], 'collection'>
+  options:
+    | {
+        collection: TSlug
+      }
+    | Options<TSlug>
 ) {
   return useReactQuery<PaginatedDocs<DataFromCollectionSlug<TSlug>>>({
-    queryKey: [collection, options],
-    queryFn: () => queryCollection(collection, options)
+    queryKey: [options.collection, options],
+    queryFn: () => queryCollection(options)
   })
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@radix-ui/react-toast": "^1.2.2",
     "@supabase/ssr": "^0.5.1",
     "@tailwindcss/typography": "^0.5.15",
+    "@tanstack/react-query": "^5.59.16",
     "class-variance-authority": "^0.7.0",
     "cloudinary": "^2.5.1",
     "clsx": "^2.1.1",
@@ -44,7 +45,6 @@
     "react-dom": "19.0.0-rc-65a56d0e-20241020",
     "sharp": "^0.33.5",
     "streamifier": "^0.1.1",
-    "swr": "^2.2.5",
     "tailwind-merge": "^2.4.0",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.15
         version: 0.5.15(tailwindcss@3.4.13(ts-node@10.9.1(@swc/core@1.6.1(@swc/helpers@0.5.13))(@types/node@20.16.11)(typescript@5.6.3)))
+      '@tanstack/react-query':
+        specifier: ^5.59.16
+        version: 5.59.16(react@19.0.0-rc-65a56d0e-20241020)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -111,9 +114,6 @@ importers:
       streamifier:
         specifier: ^0.1.1
         version: 0.1.1
-      swr:
-        specifier: ^2.2.5
-        version: 2.2.5(react@19.0.0-rc-65a56d0e-20241020)
       tailwind-merge:
         specifier: ^2.4.0
         version: 2.5.4
@@ -1966,6 +1966,14 @@ packages:
     resolution: {integrity: sha512-AqhlCXl+8grUz8uqExv5OTtgpjuVIwFTSXTrh8y9/pw6q2ek7fJ+Y8ZEVw7EB2DCcuCOtEjf9w3+J3rzts01uA==}
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20'
+
+  '@tanstack/query-core@5.59.16':
+    resolution: {integrity: sha512-crHn+G3ltqb5JG0oUv6q+PMz1m1YkjpASrXTU+sYWW9pLk0t2GybUHNRqYPZWhxgjPaVGC4yp92gSFEJgYEsPw==}
+
+  '@tanstack/react-query@5.59.16':
+    resolution: {integrity: sha512-MuyWheG47h6ERd4PKQ6V8gDyBu3ThNG22e1fRVwvq6ap3EqsFhyuxCAwhNP/03m/mLg+DAb0upgbPaX6VB+CkQ==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
@@ -4566,11 +4574,6 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  swr@2.2.5:
-    resolution: {integrity: sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==}
-    peerDependencies:
-      react: ^16.11.0 || ^17.0.0 || ^18.0.0
-
   tabbable@6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
 
@@ -4784,11 +4787,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  use-sync-external-store@1.2.2:
-    resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
   utf8-byte-length@1.0.5:
     resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
@@ -7284,6 +7282,13 @@ snapshots:
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
       tailwindcss: 3.4.13(ts-node@10.9.1(@swc/core@1.6.1(@swc/helpers@0.5.13))(@types/node@20.16.11)(typescript@5.6.3))
+
+  '@tanstack/query-core@5.59.16': {}
+
+  '@tanstack/react-query@5.59.16(react@19.0.0-rc-65a56d0e-20241020)':
+    dependencies:
+      '@tanstack/query-core': 5.59.16
+      react: 19.0.0-rc-65a56d0e-20241020
 
   '@tokenizer/token@0.3.0': {}
 
@@ -10199,12 +10204,6 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  swr@2.2.5(react@19.0.0-rc-65a56d0e-20241020):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.0.0-rc-65a56d0e-20241020
-      use-sync-external-store: 1.2.2(react@19.0.0-rc-65a56d0e-20241020)
-
   tabbable@6.2.0: {}
 
   tailwind-merge@2.5.4: {}
@@ -10436,10 +10435,6 @@ snapshots:
       tslib: 2.7.0
     optionalDependencies:
       '@types/react': types-react@19.0.0-rc.1
-
-  use-sync-external-store@1.2.2(react@19.0.0-rc-65a56d0e-20241020):
-    dependencies:
-      react: 19.0.0-rc-65a56d0e-20241020
 
   utf8-byte-length@1.0.5: {}
 


### PR DESCRIPTION
This pull request includes several commits that refactor and update the useQuery function. The commits remove the use of swr and replace it with react-query. They also move the QueryClientProvider to its own component and update the useQuery function to accept an options object. Additionally, there are fixes related to moving the collection slug to options and using useActionState instead of useFormState. The changes improve the functionality and organization of the code.